### PR TITLE
Add Android native module

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,6 +193,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.parsely:parsely:4.1.0")
 }
 
 if (rnVersion < versionToNumber(0, 75, 0)) {

--- a/android/app/src/main/java/com/parsely/react_native_example/AppPackage.kt
+++ b/android/app/src/main/java/com/parsely/react_native_example/AppPackage.kt
@@ -1,0 +1,20 @@
+package com.parsely.react_native_example
+
+import android.view.View
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ReactShadowNode
+import com.facebook.react.uimanager.ViewManager
+import com.parsely.react_native_example.ParselyNativeModule
+
+class AppPackage : ReactPackage {
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext
+    ): MutableList<ViewManager<View, ReactShadowNode<*>>> = mutableListOf()
+
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext
+    ): MutableList<NativeModule> = listOf(ParselyNativeModule(reactContext)).toMutableList()
+}

--- a/android/app/src/main/java/com/parsely/react_native_example/MainApplication.kt
+++ b/android/app/src/main/java/com/parsely/react_native_example/MainApplication.kt
@@ -21,9 +21,11 @@ class MainApplication : Application(), ReactApplication {
         this,
         object : DefaultReactNativeHost(this) {
           override fun getPackages(): List<ReactPackage> {
-            // Packages that cannot be autolinked yet can be added manually here, for example:
-            // packages.add(new MyReactNativePackage());
-            return PackageList(this).packages
+            return PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // packages.add(new MyReactNativePackage());
+              add(AppPackage())
+            }
           }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"

--- a/android/app/src/main/java/com/parsely/react_native_example/MainApplication.kt
+++ b/android/app/src/main/java/com/parsely/react_native_example/MainApplication.kt
@@ -15,6 +15,8 @@ import com.facebook.soloader.SoLoader
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 
+import com.parsely.react_native_example.AppPackage
+
 class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(

--- a/android/app/src/main/java/com/parsely/react_native_example/ParselyNativeModule.kt
+++ b/android/app/src/main/java/com/parsely/react_native_example/ParselyNativeModule.kt
@@ -5,6 +5,8 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 
+import com.parsely.parselyandroid.ParselyTracker;
+
 class ParselyNativeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
     // Note: The name and all the method signatures must be the same as the Swift implementation.
@@ -13,21 +15,38 @@ class ParselyNativeModule(reactContext: ReactApplicationContext) : ReactContextB
 
     @ReactMethod
     fun configureWithSiteId(siteId: String) {
-        Log.d("ParselyNativeModule", "Stub for configuration method. Input: $siteId")
+        val context = this.reactApplicationContext
+        val activity = currentActivity
+
+        if (activity == null) {
+            Log.e("ParselyNativeModule", "Unable to initialize ParselyTracker: currentActivity is null!")
+            // TODO: Should we fail or throw an error here to avoid giving the user the impression the SDK started successfully?
+            return
+        }
+
+        activity.runOnUiThread {
+            ParselyTracker.init(siteId, 30, this.reactApplicationContext, false)
+            Log.d("ParselyNativeModule", "ParselyTracker configured with: $siteId")
+        }
     }
 
     @ReactMethod
     fun startEngagementWithURL(urlString: String) {
-        Log.d("ParselyNativeModule", "Stub for start engagement method. Input: $urlString")
+        // "Engagement session cannot start without calling trackPageview first"
+        trackPageViewWithURL(urlString)
+        ParselyTracker.sharedInstance().startEngagement(urlString)
+        Log.d("ParselyNativeModule", "Engagement started with: $urlString")
     }
 
     @ReactMethod
     fun trackPageViewWithURL(urlString: String) {
-        Log.d("ParselyNativeModule", "Stub for track page view method. Input: $urlString")
+        ParselyTracker.sharedInstance().trackPageview(urlString)
+        Log.d("ParselyNativeModule", "Page view tracked with: $urlString")
     }
 
     @ReactMethod
     fun stopEngagement() {
-        Log.d("ParselyNativeModule", "Stub for stop method")
+        ParselyTracker.sharedInstance().stopEngagement()
+        Log.d("ParselyNativeModule", "Engagement stopped")
     }
 }

--- a/android/app/src/main/java/com/parsely/react_native_example/ParselyNativeModule.kt
+++ b/android/app/src/main/java/com/parsely/react_native_example/ParselyNativeModule.kt
@@ -16,14 +16,17 @@ class ParselyNativeModule(reactContext: ReactApplicationContext) : ReactContextB
         Log.d("ParselyNativeModule", "Stub for configuration method. Input: $siteId")
     }
 
+    @ReactMethod
     fun startEngagementWithURL(urlString: String) {
         Log.d("ParselyNativeModule", "Stub for start engagement method. Input: $urlString")
     }
 
+    @ReactMethod
     fun trackPageViewWithURL(urlString: String) {
         Log.d("ParselyNativeModule", "Stub for track page view method. Input: $urlString")
     }
 
+    @ReactMethod
     fun stopEngagement() {
         Log.d("ParselyNativeModule", "Stub for stop method")
     }

--- a/android/app/src/main/java/com/parsely/react_native_example/ParselyNativeModule.kt
+++ b/android/app/src/main/java/com/parsely/react_native_example/ParselyNativeModule.kt
@@ -1,0 +1,30 @@
+package com.parsely.react_native_example
+
+import android.util.Log
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class ParselyNativeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+
+    // Note: The name and all the method signatures must be the same as the Swift implementation.
+
+    override fun getName() = "ParselyNativeModule"
+
+    @ReactMethod
+    fun configureWithSiteId(siteId: String) {
+        Log.d("ParselyNativeModule", "Stub for configuration method. Input: $siteId")
+    }
+
+    fun startEngagementWithURL(urlString: String) {
+        Log.d("ParselyNativeModule", "Stub for start engagement method. Input: $urlString")
+    }
+
+    fun trackPageViewWithURL(urlString: String) {
+        Log.d("ParselyNativeModule", "Stub for track page view method. Input: $urlString")
+    }
+
+    fun stopEngagement() {
+        Log.d("ParselyNativeModule", "Stub for stop method")
+    }
+}


### PR DESCRIPTION
Adds proof of concept for Android native module connecting to the Parsely Android SDK.

Here are the logs showing the methods from the native module being called as well as the underlying SDK ones:

<img width="1669" alt="image" src="https://github.com/user-attachments/assets/2677a564-4b43-43b0-b1c1-42330e4283a3">
